### PR TITLE
Initial version

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+# ts sources
+/lib
+index.ts
+
+# descriptors
+@types

--- a/@types/doctrine/doctrine.d.ts
+++ b/@types/doctrine/doctrine.d.ts
@@ -1,0 +1,24 @@
+// d.ts file for doctrine.
+// Only the bare minimal has been declared here.
+declare namespace doctrine {
+    export interface Comment {
+        description: string;
+        tags: Tag[];
+    }
+
+    export interface Tag {
+        title: string;
+        description: string;
+        type: Type;
+    }
+
+    export interface Type {
+        type: string;
+        name: string;
+    }
+}
+
+declare module 'doctrine' {
+    export function parse(code: string | Buffer, options: any): Comment;
+}
+export = doctrine;

--- a/@types/espree/espree.d.ts
+++ b/@types/espree/espree.d.ts
@@ -1,0 +1,20 @@
+// d.ts file for espree.
+// Only the bare minimal has been declared here.
+declare namespace espree {
+    interface Comment {
+        value: string;
+    }
+    interface ParseOptions {
+        comments: boolean;
+        attachComment: boolean;
+    }
+    interface Ast {
+        comments: Comment[];
+    }
+}
+
+declare module 'espree' {
+    export function parse(code: string | Buffer, options: any): espree.Ast;
+}
+
+export = espree;

--- a/README.md
+++ b/README.md
@@ -1,2 +1,142 @@
 # yadop
-Yet Another Doc Parser
+Yadop (Yet Another Doc Parser) is a [JSDoc](http://usejsdoc.org) parser that uses [Espree](https://github.com/eslint/espree) and [Doctrine](https://github.com/eslint/doctrine) to process your sources.
+
+## Installation
+
+You can install Yadop using [npm](https://npmjs.com):
+
+```
+$ npm install yadop --save-dev
+```
+
+## Usage
+
+Require yadop inside of your JavaScript:
+
+```js
+var yadop = require("yadop");
+```
+
+#### JSDoc
+
+In order to process the jsdoc you can execute the following:
+
+```js
+yadop.jsdoc.processor({
+    cwd: 'directory/containing/sources', // the source directory
+    pattern: '*/*.js' // the pattern
+}).process();
+```
+
+#### NGDoc
+
+In order to process the ngdoc you can execute the following:
+
+```js
+var comments = yadop.ngdoc.processor({
+    cwd: 'directory/containing/sources', // the source directory
+    pattern: '*/*.js' // the pattern
+}).process();
+
+var results = yadop.ngdoc.mapper().map(comments);
+```
+
+## Configuration
+
+Both the yadop.jsdoc.processor and the yadop.ngdoc.processor are called with a configuration object.
+This object contains the following attributes:
+
+##### cwd
+Type: `string`
+Default: current working directory
+Mandatory: false
+
+The current working directory.
+
+##### pattern
+Type: `string`
+Default: **/*.js
+Mandatory: false
+
+The file pattern.
+
+##### ignore
+Type: `string`
+Default: []
+Mandatory: false
+
+The ignore patterns.
+
+### Example
+
+```js
+{
+    cwd: 'directory/containing/sources', // the source directory
+    pattern: '*/*.js' // the pattern
+}
+```
+
+## Available functions
+
+#### yadop.jsdoc.processor
+Type: `Function`
+Param: `Configuration` The configuration object as seen above.
+Returns: [doctrine](https://github.com/eslint/doctrine)Comment[]
+
+Processes jsdoc for each file in the specified cwd.
+
+#### yadop.ngdoc.processor
+Type: `Function`
+Param: `Configuration`
+Returns: [doctrine](https://github.com/eslint/doctrine)Comment[]
+
+Processes jsdoc for each file in the specified cwd but only containing the ngdoc tags.
+
+#### yadop.ngdoc.mapper
+Type: `Function`
+Param: [doctrine](https://github.com/eslint/doctrine)`Comment[]` 
+Returns: [yadop](blob/initial/lib/ngdoc/model/module.ts)Module[]
+
+Processes a [doctrine](https://github.com/eslint/doctrine)Comment[] and returns a [yadop](blob/initial/lib/ngdoc/model/module.ts)module[]. 
+
+## Example
+```json
+[{ "name": "my-module" }, {
+    "name": "another-module",
+    "entities": [{
+        "name": "my-component",
+        "type": "component",
+        "attributes": [{
+            "name": "items",
+            "optional": false,
+            "description": "Some attribute",
+            "type": "Object[]"
+        }, {
+            "name": "items[].name",
+            "optional": true,
+            "description": "The (optional) name of the item",
+            "type": "string"
+        }, {
+            "name": "items[].value",
+            "optional": false,
+            "description": "The value of the item",
+            "type": "number"
+        }]
+    }, {
+        "name": "SomeService",
+        "type": "service",
+        "methods": [{
+            "name": "SomeService#sayWhat",
+            "description": "Says what.",
+            "params": [{ "name": "who", "description": "Who said it", "type": "string" }, {
+                "name": "when",
+                "description": "When to say"
+            }]
+        }, {
+            "name": "SomeService#welcome",
+            "description": "Say welcome",
+            "returns": { "name": "message The message", "type": "object" }
+        }]
+    }, { "name": "AnotherService", "type": "service" }]
+}]
+```

--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,24 @@
+import Configuration from './lib/configuration';
+import Processor from './lib/processor';
+import NgdocProcessor from './lib/ngdoc/ngdocProcessor';
+import NgdocMapper from './lib/ngdoc/ngdocMapper';
+
+(() => {
+    'use strict';
+
+    module.exports = {
+        jsdoc: {
+            processor: (configuration: Configuration) => {
+                return new Processor(configuration);
+            }
+        },
+        ngdoc: {
+            processor: (configuration: Configuration) => {
+                return new NgdocProcessor(configuration);
+            },
+            mapper: () => {
+                return new NgdocMapper()
+            }
+        }
+    }
+})();

--- a/lib/configuration.ts
+++ b/lib/configuration.ts
@@ -1,0 +1,8 @@
+/** Configuration information that is necessary for the processor to process docs. */
+interface Configuration {
+    cwd?: string;
+    pattern?: string;
+    ignore?: string[];
+}
+
+export default Configuration;

--- a/lib/ngdoc/model/attributeType.ts
+++ b/lib/ngdoc/model/attributeType.ts
@@ -1,0 +1,6 @@
+export interface AttributeType {
+    name: string;
+    description?: string;
+    type?: string;
+    optional: boolean;
+}

--- a/lib/ngdoc/model/entity.ts
+++ b/lib/ngdoc/model/entity.ts
@@ -1,0 +1,10 @@
+import {Method} from './method';
+import {AttributeType} from './attributeType';
+
+export interface Entity {
+    name: string;
+    description?: string;
+    type?: string;
+    methods?: Method[];
+    attributes?: AttributeType[];
+}

--- a/lib/ngdoc/model/entityType.ts
+++ b/lib/ngdoc/model/entityType.ts
@@ -1,0 +1,6 @@
+export enum EntityType {
+    COMPONENT = 0,
+    SERVICE = 1,
+    DIRECTIVE = 2,
+    FILTER = 3
+}

--- a/lib/ngdoc/model/method.ts
+++ b/lib/ngdoc/model/method.ts
@@ -1,0 +1,10 @@
+import {ReturnType} from './returnType';
+import {ParamType} from './paramType';
+
+export interface Method {
+    name: string;
+    description?: string;
+    returns?: ReturnType;
+    params?: ParamType[];
+}
+

--- a/lib/ngdoc/model/module.ts
+++ b/lib/ngdoc/model/module.ts
@@ -1,0 +1,6 @@
+import {Entity} from './entity';
+
+export interface Module {
+    name: string;
+    entities?: Entity[];
+}

--- a/lib/ngdoc/model/paramType.ts
+++ b/lib/ngdoc/model/paramType.ts
@@ -1,0 +1,5 @@
+export interface ParamType {
+    name: string;
+    description?: string;
+    type?: string;
+}

--- a/lib/ngdoc/model/returnType.ts
+++ b/lib/ngdoc/model/returnType.ts
@@ -1,0 +1,4 @@
+export interface ReturnType {
+    name: string;
+    type?: string;
+}

--- a/lib/ngdoc/ngdocMapper.spec.ts
+++ b/lib/ngdoc/ngdocMapper.spec.ts
@@ -1,0 +1,196 @@
+import * as doctrine from 'doctrine';
+import NgdocMapper from './ngdocMapper';
+import {Module} from './model/module';
+import {Entity} from './model/entity';
+import {Method} from './model/method';
+
+(() => {
+    describe('ngdoc mapper', () => {
+        let mapper: NgdocMapper;
+
+        const comments: doctrine.Comment[] = [{
+            tags: [
+                { title: 'ngdoc', description: 'module' },
+                { title: 'name', description: null, name: 'my-module' }
+            ]
+        } as doctrine.Comment, {
+            tags: [
+                { title: 'description', description: 'something' } // just a comment
+            ]
+        } as doctrine.Comment, {
+            tags: [
+                { title: 'ngdoc', description: 'module' },
+                { title: 'name', description: null, name: 'another-module' }
+            ]
+        } as doctrine.Comment, {
+            tags: [
+                { title: 'ngdoc', description: 'component' },
+                { title: 'module', description: null, type: null, name: 'another-module' },
+                { title: 'name', description: null, name: 'my-component' },
+                { title: 'description', description: 'This component does something for me' },
+                {
+                    title: 'param', description: 'Some attribute',
+                    type: {
+                        type: 'TypeApplication', expression: { type: 'NameExpression', name: 'Array' },
+                        applications: [{ type: 'NameExpression', name: 'Object' }]
+                    },
+                    name: 'items'
+                }, {
+                    title: 'param', description: 'The (optional) name of the item',
+                    type: {
+                        type: 'OptionalType',
+                        expression: {
+                            type: 'NameExpression',
+                            name: 'string'
+                        }
+                    },
+                    name: 'items[].name'
+                },
+                {
+                    title: 'param', description: 'The value of the item',
+                    type: {
+                        type: 'NameExpression',
+                        name: 'number'
+                    },
+                    name: 'items[].value'
+                },
+            ]
+        }  as doctrine.Comment, { // an entity
+            tags: [
+                { title: 'ngdoc', description: 'service' },
+                { title: 'module', description: null, type: null, name: 'another-module' },
+                { title: 'name', description: null, name: 'SomeService' },
+                { title: 'description', description: 'Some service' }
+            ]
+        }  as doctrine.Comment, { // another entity
+            tags: [
+                { title: 'ngdoc', description: 'service' },
+                { title: 'module', description: null, type: null, name: 'another-module' },
+                { title: 'name', description: null, name: 'AnotherService' },
+                { title: 'description', description: 'Another service' }
+            ]
+        }  as doctrine.Comment, { // another entity, but does not match a valid entity type
+            tags: [
+                { title: 'ngdoc', description: 'invalid-type' },
+                { title: 'module', description: null, type: null, name: 'another-module' },
+                { title: 'name', description: null, name: 'another-component' },
+                { title: 'description', description: 'This component does something for someone else' }
+            ]
+        }  as doctrine.Comment, { // an entity method
+            tags: [
+                { title: 'ngdoc', description: 'method' },
+                { title: 'methodOf', description: 'SomeService' },
+                { title: 'name', description: null, name: 'SomeService#sayWhat' },
+                { title: 'description', description: 'Says what.' },
+                {
+                    title: 'param', description: 'Who said it', name: 'who',
+                    type: { type: 'NameExpression', name: 'string' }
+                },
+                { title: 'param', description: 'When to say', name: 'when', 'type': null } // no type
+            ]
+        } as doctrine.Comment, { // another entity method
+            tags: [
+                { title: 'ngdoc', description: 'method' },
+                { title: 'methodOf', description: 'SomeService' },
+                { title: 'name', description: null, name: 'SomeService#welcome' },
+                { title: 'description', description: 'Say welcome' },
+                {
+                    title: 'return', description: 'message The message',
+                    type: { type: 'NameExpression', name: 'object' }
+                }
+            ]
+        } as doctrine.Comment];
+
+
+        beforeEach(() => {
+            mapper = new NgdocMapper();
+        });
+
+        describe('map', () => {
+
+            it('maps', () => {
+                const actual: Module[] = mapper.map(comments);
+                const expected = [{ name: 'my-module' }, {
+                    name: 'another-module',
+                    entities: [{
+                        name: 'my-component',
+                        type: 'component',
+                        attributes: [{
+                            name: 'items',
+                            optional: false,
+                            description: 'Some attribute',
+                            type: 'Object[]'
+                        }, {
+                            name: 'items[].name',
+                            optional: true,
+                            description: 'The (optional) name of the item',
+                            type: 'string'
+                        }, {
+                            name: 'items[].value',
+                            optional: false,
+                            description: 'The value of the item',
+                            type: 'number'
+                        }]
+                    }, {
+                        name: 'SomeService',
+                        type: 'service',
+                        methods: [{
+                            name: 'SomeService#sayWhat',
+                            description: 'Says what.',
+                            params: [{ name: 'who', description: 'Who said it', type: 'string' }, {
+                                name: 'when',
+                                description: 'When to say'
+                            }]
+                        }, {
+                            name: 'SomeService#welcome',
+                            description: 'Say welcome',
+                            returns: { name: 'message The message', type: 'object' }
+                        }]
+                    }, { name: 'AnotherService', type: 'service' }]
+                }];
+                expect(actual).toEqual(expected)
+            });
+        });
+
+        describe('getModules', () => {
+            it('gets the modules', () => {
+                const modules: Module[] = mapper.getModules(comments);
+                expect(modules.length).toBe(2);
+                expect(modules[0]).toEqual({ name: 'my-module' });
+                expect(modules[1]).toEqual({ name: 'another-module' });
+            });
+        });
+
+        describe('getEntities', () => {
+            it('gets the valid entities', () => {
+                const entities: Entity[] = mapper.getEntities(comments, { name: 'another-module' });
+                expect(entities.length).toBe(3);
+                expect(entities[0]).toEqual({ name: 'my-component', type: 'component' });
+                expect(entities[1]).toEqual({ name: 'SomeService', type: 'service' });
+                expect(entities[2]).toEqual({ name: 'AnotherService', type: 'service' });
+            });
+        });
+
+        describe('getMethod', () => {
+            it('gets the methods', () => {
+                const serviceMethod: Method[] = mapper.getMethods(comments, {
+                    name: 'SomeService',
+                    type: 'service'
+                });
+                expect(serviceMethod.length).toBe(2);
+                expect(serviceMethod[0]).toEqual({
+                    name: 'SomeService#sayWhat', description: 'Says what.',
+                    params: [
+                        { name: 'who', description: 'Who said it', type: 'string' }, // with a type
+                        { name: 'when', description: 'When to say' } // without type (not specified)
+                    ] // no return type
+                });
+                expect(serviceMethod[1]).toEqual({
+                    name: 'SomeService#welcome',
+                    description: 'Say welcome',
+                    returns: { name: 'message The message', type: 'object' }
+                });
+            });
+        });
+    });
+})();

--- a/lib/ngdoc/ngdocMapper.spec.ts
+++ b/lib/ngdoc/ngdocMapper.spec.ts
@@ -110,11 +110,12 @@ import {Method} from './model/method';
 
             it('maps', () => {
                 const actual: Module[] = mapper.map(comments);
-                const expected = [{ name: 'my-module' }, {
+                const expected = [{ name: 'my-module', entities: [] }, {
                     name: 'another-module',
                     entities: [{
                         name: 'my-component',
                         type: 'component',
+                        methods: [],
                         attributes: [{
                             name: 'items',
                             optional: false,
@@ -145,8 +146,9 @@ import {Method} from './model/method';
                             name: 'SomeService#welcome',
                             description: 'Say welcome',
                             returns: { name: 'message The message', type: 'object' }
-                        }]
-                    }, { name: 'AnotherService', type: 'service' }]
+                        }],
+                        attributes: []
+                    }, { name: 'AnotherService', type: 'service', methods: [], attributes: [] }]
                 }];
                 expect(actual).toEqual(expected)
             });

--- a/lib/ngdoc/ngdocMapper.ts
+++ b/lib/ngdoc/ngdocMapper.ts
@@ -1,0 +1,273 @@
+import * as doctrine from 'doctrine';
+import {tags} from './tags';
+import {Module} from './model/module';
+import {Entity} from './model/entity';
+import {Method} from './model/method';
+import {ReturnType} from './model/returnType';
+import {ParamType} from './model/paramType';
+import {EntityType} from './model/entityType';
+import {AttributeType} from './model/attributeType';
+
+/** Ngdoc comments mapper. */
+class NgdocMapper {
+
+    /**
+     * Maps the comments to a workable output.
+     * @param comments The comments.
+     */
+    map(comments: doctrine.Comment[]): any {
+        const modules: Module[] = this.getModules(comments);
+        modules.forEach((module: Module) => {
+            module.entities = this.getEntities(comments, module);
+
+            module.entities.forEach((entity: Entity) => {
+                entity.methods = this.getMethods(comments, entity);
+                entity.attributes = this.getAttributes(comments, module, entity);
+            });
+        });
+        return modules;
+    }
+
+    /**
+     * Gets all the modules.
+     * @param {doctrine.Comment[]} comments The comments.
+     * @returns {Module[]} modules The modules.
+     */
+    getModules = (comments: doctrine.Comment[]): Module[] => comments
+        .filter(this._onCommentsContainingTheModuleAnnotation)
+        .map(this._toModule);
+
+    /**
+     * Gets all the entities for the given module.
+     * @param {doctrine.Comment[]} comments The comments.
+     * @param {Module} module The module.
+     * @returns {Entity[]} entities The entities.
+     */
+    getEntities = (comments: doctrine.Comment[], module: Module): Entity[] => comments
+        .filter(this._onCommentsMatchingModule(module))
+        .filter(this._onValidEntityType)
+        .map(this._toEntity);
+
+    /**
+     * Gets all the methods for the given entity.
+     * @param {doctrine.Comment[]} comments The comments.
+     * @param {Entity} entity The entity.
+     * @returns {Method[]} methods The methods.
+     */
+    getMethods = (comments: doctrine.Comment[], entity: Entity): Method[] => comments
+        .filter(this._onCommentsMatchingMethodsOfEntity(entity))
+        .filter(this._onTagsMatchingMethod)
+        .map(this._toMethod);
+
+    /**
+     * Gets all the attributes for the given entity.
+     * @param {doctrine.Comment[]} comments The comments.
+     * @param {Module} module The module.
+     * @param {Entity} entity The entity.
+     * @returns {AttributeType[]} attributes The attributes.
+     */
+    getAttributes = (comments: doctrine.Comment[], module: Module, entity: Entity): AttributeType[] => {
+        const comment = comments
+            .filter(this._onCommentsMatchingModule(module))
+            .find(this._onTagsMatchingEntity(entity));
+
+        let attributes: AttributeType[] = [];
+        if (comment !== undefined && comment.tags !== undefined) {
+            attributes = comment.tags.filter(tags.annotations.param).map((tag: any) => {
+                const attributeType: AttributeType = {
+                    name: tag.name,
+                    optional: false
+                };
+
+                if (tag.description !== null) {
+                    attributeType.description = tag.description;
+                }
+
+                if (tag.type !== null) {
+                    let type = tag.type;
+                    if (type.type === 'OptionalType') {
+                        attributeType.optional = true;
+                        type = type.expression;
+                    }
+
+                    if (type.type === 'TypeApplication') {
+                        if (type.expression.name === 'Array') {
+                            attributeType.type = type.applications
+                                    .map((application) => application.name)
+                                    .join() + '[]';
+                        }
+                    } else {
+                        attributeType.type = type.name;
+                    }
+                }
+                return attributeType;
+            });
+        }
+        return attributes;
+    };
+
+
+    /**
+     * Indicates if the comment contains tag @ngdoc module.
+     * @param {doctrine.Comment} comment The comment.
+     * @return {boolean} indicator The indicator.
+     * @private
+     */
+    private _onCommentsContainingTheModuleAnnotation = (comment: doctrine.Comment): boolean => comment.tags
+        .filter(tags.annotations.ngdoc)
+        .filter(tags.values.module).length > 0;
+
+    /**
+     * Converts the given comment to a Module.
+     * @param {doctrine.Comment} comment The comment.
+     * @return {Module} module The module.
+     * @private
+     */
+    private _toModule = (comment: doctrine.Comment): Module => ({
+        name: (comment.tags.find((tag) => tag.title === 'name') as any).name
+    });
+
+    /**
+     * Indicates if the comment matches the given module name.
+     * @param {Module} module The module.
+     * @return {boolean} indicator The indicator.
+     * @private
+     */
+    private _onCommentsMatchingModule = (module: Module) => (comment: doctrine.Comment): boolean => comment.tags
+        .filter(tags.annotations.module)
+        .filter((tag: any) => tag.name === module.name) // match module name
+        .length > 0;
+
+    /**
+     * Indicates if the entity type is valid.
+     * @param {doctrine.Comment} comment The comment.
+     * @return {boolean} indicator The indicator.
+     * @private
+     */
+    private _onValidEntityType = (comment: doctrine.Comment): boolean => comment.tags
+        .filter(tags.annotations.ngdoc)
+        .filter(this._existingEntityType)
+        .length > 0;
+
+    /**
+     * Indicates if the entity type exists.
+     * @param {doctrine.Tag} tag The tag.
+     * @return {boolean} indicator The indicator.
+     * @private
+     */
+    private _existingEntityType = (tag: doctrine.Tag): boolean => EntityType[tag.description.toUpperCase()] !== undefined;
+
+    /**
+     * Converts the given comment to an Entity.
+     * @param {doctrine.Comment} comment The entity.
+     * @return {Entity} entity The entity.
+     * @private
+     */
+    private _toEntity = (comment: doctrine.Comment): Entity => ({
+        name: (comment.tags.find(tags.annotations.name)as any).name,
+        type: comment.tags.find(tags.annotations.ngdoc).description
+    });
+
+    /**
+     * Indicates if the comment matches the given entity name.
+     * @param {Entity} entity The entity.
+     * @return {boolean} indicator The indicator.
+     * @private
+     */
+    private _onCommentsMatchingMethodsOfEntity = (entity: Entity) => (comment: doctrine.Comment): boolean => comment.tags
+        .filter(tags.annotations.methodOfTag)
+        .filter((tag: any) => tag.description === entity.name)
+        .length > 0;
+
+    /**
+     * Indicates if the comment contains tag @method.
+     * @param {doctrine.Comment} comment The entity.
+     * @return {boolean} indicator The indicator.
+     * @private
+     */
+    private _onTagsMatchingMethod = (comment: doctrine.Comment): boolean => comment.tags
+        .filter(tags.annotations.ngdoc)
+        .filter(tags.values.method)
+        .length > 0;
+
+    /**
+     * Indicates if the comment contains tag @method.
+     * @param {doctrine.Comment} comment The entity.
+     * @return {boolean} indicator The indicator.
+     * @private
+     */
+    private _onTagsMatchingEntity = (entity: Entity) => (comment: doctrine.Comment): boolean => comment.tags
+        .filter((tag: any) => tag.title === 'name' && tag.name === entity.name)
+        .length > 0;
+
+    /**
+     * Converts the given comment to a method.
+     * @param {doctrine.Comment} comment The entity.
+     * @return {Method} method The method.
+     * @private
+     */
+    private _toMethod = (comment: doctrine.Comment): Method => {
+        const method: Method = {
+            name: (comment.tags.find(tags.annotations.name)as any).name,
+            description: (comment.tags.find(tags.annotations.description)as any).description,
+        };
+
+        const returnType = this._getReturn(comment);
+        if (returnType !== undefined) {
+            method.returns = returnType;
+        }
+
+        const paramTypes = this._getParams(comment);
+        if (paramTypes.length > 0) {
+            method.params = paramTypes;
+        }
+        return method;
+    };
+
+    /**
+     * Gets the return if present.
+     * @param {doctrine.Comment} comment The entity.
+     * @return {ReturnType} returnType The returnType.
+     * @private
+     */
+    private _getReturn = (comment: doctrine.Comment): ReturnType => {
+        let returnType: ReturnType;
+
+        const tag = comment.tags.find(tags.annotations.returns);
+        if (tag !== undefined) {
+            returnType = {
+                name: tag.description
+            };
+            if (tag.type !== null) {
+                returnType.type = tag.type.name;
+            }
+        }
+        return returnType;
+    };
+
+    /**
+     * Gets the parameters if present.
+     * @param {doctrine.Comment} comment The entity.
+     * @return {ParamType[]} paramTypes The paramTypes.
+     * @private
+     */
+    private _getParams = (comment: doctrine.Comment): ParamType[] => {
+        const paramTypes: ParamType[] = [];
+
+        comment.tags.filter(tags.annotations.param).forEach((tag: any) => {
+            const paramType: ParamType = {
+                name: tag.name,
+            };
+            if (tag.description !== null) {
+                paramType.description = tag.description;
+            }
+            if (tag.type !== null) {
+                paramType.type = tag.type.name;
+            }
+            paramTypes.push(paramType);
+        });
+        return paramTypes;
+    };
+}
+
+export default NgdocMapper;

--- a/lib/ngdoc/ngdocProcessor.spec.ts
+++ b/lib/ngdoc/ngdocProcessor.spec.ts
@@ -1,0 +1,86 @@
+import * as fs from 'fs-extra';
+import * as glob from 'glob';
+import * as sinon from 'sinon';
+import * as espree from 'espree';
+import * as doctrine from 'doctrine';
+import Configuration from '../configuration';
+import NgdocProcessor from './ngdocProcessor';
+
+(() => {
+    describe('processor', () => {
+        let globSyncFn: sinon.SinonStub;
+        let fsReadFileSyncFn: sinon.SinonStub;
+        let espreeParseFn: sinon.SinonStub;
+        let doctrineParseFn: sinon.SinonStub;
+
+        let configuration: Configuration;
+        let processor: NgdocProcessor;
+        let result: doctrine.Comment[];
+
+        const code = 'code';
+
+        beforeEach(() => {
+            globSyncFn = sinon.stub(glob, 'sync').callsFake(() => [
+                'one', 'two', 'three'
+            ]);
+            fsReadFileSyncFn = sinon.stub(fs, 'readFileSync').callsFake((file) => file + '-content');
+
+            espreeParseFn = sinon.stub(espree, 'parse');
+            espreeParseFn.onCall(0).returns({ comments: [{ value: 'one' }] });
+            espreeParseFn.onCall(1).returns({ comments: [{ value: 'two' }, { value: 'another two' }] });
+            espreeParseFn.onCall(2).returns({ comments: [{ value: 'three' }] });
+
+            doctrineParseFn = sinon.stub(doctrine, 'parse');
+            doctrineParseFn.onCall(0).returns({
+                description: 'one-doctrine',
+                tags: [{ title: 'param', "description": "some param" }]
+            });
+            doctrineParseFn.onCall(1).returns({
+                description: 'two-doctrine',
+                tags: [{ title: 'param', "description": "some param" }]
+            });
+            doctrineParseFn.onCall(2).returns({
+                description: 'another two-doctrine',
+                tags: [{ title: 'ngdoc', "description": "some param" }]
+            });
+            doctrineParseFn.onCall(3).returns({
+                description: 'three-doctrine',
+                tags: [{ title: 'ngdoc', "description": "some param" }]
+            });
+        });
+
+        describe('process', () => {
+            beforeEach(() => {
+                configuration = {};
+                processor = new NgdocProcessor(configuration);
+                result = processor.process();
+            });
+
+            it('returns the only the ngdoc doctrine comments', () => {
+                expect(result.length).toBe(2);
+                expect(result[0]).toEqual({
+                    description: 'another two-doctrine',
+                    tags: [{ title: 'ngdoc', "description": "some param" }]
+                } as doctrine.Comment);
+                expect(result[1]).toEqual({
+                    description: 'three-doctrine',
+                    tags: [{ title: 'ngdoc', "description": "some param" }]
+                } as doctrine.Comment);
+            });
+
+            afterEach(() => {
+                globSyncFn.reset();
+                fsReadFileSyncFn.reset();
+                espreeParseFn.reset();
+                doctrineParseFn.reset();
+            });
+        });
+
+        afterEach(() => {
+            globSyncFn.restore();
+            fsReadFileSyncFn.restore();
+            espreeParseFn.restore();
+            doctrineParseFn.restore();
+        });
+    });
+})();

--- a/lib/ngdoc/ngdocProcessor.spec.ts
+++ b/lib/ngdoc/ngdocProcessor.spec.ts
@@ -7,7 +7,7 @@ import Configuration from '../configuration';
 import NgdocProcessor from './ngdocProcessor';
 
 (() => {
-    describe('processor', () => {
+    describe('ngdoc processor', () => {
         let globSyncFn: sinon.SinonStub;
         let fsReadFileSyncFn: sinon.SinonStub;
         let espreeParseFn: sinon.SinonStub;
@@ -33,19 +33,19 @@ import NgdocProcessor from './ngdocProcessor';
             doctrineParseFn = sinon.stub(doctrine, 'parse');
             doctrineParseFn.onCall(0).returns({
                 description: 'one-doctrine',
-                tags: [{ title: 'param', "description": "some param" }]
+                tags: [{ title: 'param', 'description': 'some param' }]
             });
             doctrineParseFn.onCall(1).returns({
                 description: 'two-doctrine',
-                tags: [{ title: 'param', "description": "some param" }]
+                tags: [{ title: 'param', 'description': 'some param' }]
             });
             doctrineParseFn.onCall(2).returns({
                 description: 'another two-doctrine',
-                tags: [{ title: 'ngdoc', "description": "some param" }]
+                tags: [{ title: 'ngdoc', 'description': 'some param' }]
             });
             doctrineParseFn.onCall(3).returns({
                 description: 'three-doctrine',
-                tags: [{ title: 'ngdoc', "description": "some param" }]
+                tags: [{ title: 'ngdoc', 'description': 'some param' }]
             });
         });
 
@@ -60,11 +60,11 @@ import NgdocProcessor from './ngdocProcessor';
                 expect(result.length).toBe(2);
                 expect(result[0]).toEqual({
                     description: 'another two-doctrine',
-                    tags: [{ title: 'ngdoc', "description": "some param" }]
+                    tags: [{ title: 'ngdoc', 'description': 'some param' }]
                 } as doctrine.Comment);
                 expect(result[1]).toEqual({
                     description: 'three-doctrine',
-                    tags: [{ title: 'ngdoc', "description": "some param" }]
+                    tags: [{ title: 'ngdoc', 'description': 'some param' }]
                 } as doctrine.Comment);
             });
 

--- a/lib/ngdoc/ngdocProcessor.ts
+++ b/lib/ngdoc/ngdocProcessor.ts
@@ -1,0 +1,22 @@
+import Processor from '../processor';
+import * as doctrine from 'doctrine';
+
+/** Ngdoc comment processor. */
+class NgdocProcessor extends Processor {
+
+    /** {@inheritDoc} */
+    process(): doctrine.Comment[] {
+        return super.process().filter(this._onlyCommentsContainingNgdoc);
+    }
+
+    /**
+     * Filter only allows comments containing ngdoc.
+     * @param comment The comment.
+     * @return {boolean} match Indicator match.
+     * @private
+     */
+    private _onlyCommentsContainingNgdoc = (comment: doctrine.Comment): boolean =>
+    comment.tags.filter((tag) => tag.title === 'ngdoc').length > 0;
+}
+
+export default NgdocProcessor;

--- a/lib/ngdoc/ngdocProcessor.ts
+++ b/lib/ngdoc/ngdocProcessor.ts
@@ -6,7 +6,8 @@ class NgdocProcessor extends Processor {
 
     /** {@inheritDoc} */
     process(): doctrine.Comment[] {
-        return super.process().filter(this._onlyCommentsContainingNgdoc);
+        return super.process()
+            .filter(this._onCommentsContainingNgdoc);
     }
 
     /**
@@ -15,8 +16,8 @@ class NgdocProcessor extends Processor {
      * @return {boolean} match Indicator match.
      * @private
      */
-    private _onlyCommentsContainingNgdoc = (comment: doctrine.Comment): boolean =>
-    comment.tags.filter((tag) => tag.title === 'ngdoc').length > 0;
+    private _onCommentsContainingNgdoc = (comment: doctrine.Comment): boolean =>
+        comment.tags.filter((tag) => tag.title === 'ngdoc').length > 0;
 }
 
 export default NgdocProcessor;

--- a/lib/ngdoc/tags.ts
+++ b/lib/ngdoc/tags.ts
@@ -1,0 +1,97 @@
+import * as doctrine from 'doctrine';
+export namespace tags {
+    export namespace annotations {
+        /**
+         * Indicates if the tag is contains a @name tag.
+         * @param tag The tag.
+         * @return {boolean} indicator The indicator.
+         * @private
+         */
+        export function _onlyAtTags(tag: doctrine.Tag, tagName): boolean {
+            return tag.title === tagName;
+        }
+
+        /**
+         * Indicates if the tag is contains a @ngdoc tag.
+         * @param tag The tag.
+         * @return {boolean} indicator The indicator.
+         */
+        export function ngdoc(tag: doctrine.Tag): boolean {
+            return _onlyAtTags(tag, 'ngdoc');
+        }
+
+        /**
+         * Indicates if the tag is contains a @module tag.
+         * @param tag The tag.
+         * @return {boolean} indicator The indicator.
+         */
+        export function module(tag: doctrine.Tag): boolean {
+            return _onlyAtTags(tag, 'module');
+        }
+
+        /**
+         * Indicates if the tag is contains a @methodOf tag.
+         * @param tag The tag.
+         * @return {boolean} indicator The indicator.
+         */
+        export function methodOfTag(tag: doctrine.Tag): boolean {
+            return _onlyAtTags(tag, 'methodOf');
+        }
+
+        /**
+         * Indicates if the tag is contains a @name tag.
+         * @param tag The tag.
+         * @return {boolean} indicator The indicator.
+         */
+        export function name(tag: doctrine.Tag): boolean {
+            return _onlyAtTags(tag, 'name');
+        }
+
+        /**
+         * Indicates if the tag is contains a @description tag.
+         * @param tag The tag.
+         * @return {boolean} indicator The indicator.
+         */
+        export function description(tag: doctrine.Tag): boolean {
+            return _onlyAtTags(tag, 'description');
+        }
+
+        /**
+         * Indicates if the tag is contains a @return tag.
+         * @param tag The tag.
+         * @return {boolean} indicator The indicator.
+         */
+        export function returns(tag: doctrine.Tag): boolean {
+            return _onlyAtTags(tag, 'return');
+        }
+        /**
+         * Indicates if the tag is contains a @param tag.
+         * @param tag The tag.
+         * @return {boolean} indicator The indicator.
+         */
+        export function param(tag: doctrine.Tag): boolean {
+            return _onlyAtTags(tag, 'param');
+        }
+    }
+
+    export namespace values {
+        /**
+         * Indicates if the tag is contains a @method tag.
+         * @param tag The tag.
+         * @return {boolean} indicator The indicator.
+         */
+        export function method(tag: doctrine.Tag): boolean {
+            return tag.description === 'method'
+        }
+
+        /**
+         * Indicates if the has description module. -> @ngdoc module
+         * @param tag The tag.
+         * @return {boolean} indicator The indicator.
+         */
+        export function module(tag: doctrine.Tag): boolean {
+            return tag.description === 'module';
+        }
+
+    }
+}

--- a/lib/processor.spec.ts
+++ b/lib/processor.spec.ts
@@ -1,0 +1,168 @@
+import * as fs from 'fs-extra';
+import * as glob from 'glob';
+import * as sinon from 'sinon';
+import Configuration from './configuration';
+import Processor from './processor';
+import * as espree from 'espree';
+import * as doctrine from 'doctrine';
+import * as path from 'path';
+
+(() => {
+    describe('processor', () => {
+        let globSyncFn: sinon.SinonStub;
+        let fsReadFileSyncFn: sinon.SinonStub;
+        let espreeParseFn: sinon.SinonStub;
+        let doctrineParseFn: sinon.SinonStub;
+
+        let configuration: Configuration;
+        let processor: Processor;
+        let result: doctrine.Comment[];
+
+        const code = 'code';
+
+        beforeEach(() => {
+            globSyncFn = sinon.stub(glob, 'sync').callsFake(() => [
+                'one', 'two', 'three'
+            ]);
+            fsReadFileSyncFn = sinon.stub(fs, 'readFileSync').callsFake((file) => file + '-content');
+
+            espreeParseFn = sinon.stub(espree, 'parse');
+            espreeParseFn.onCall(0).returns({ comments: [{ value: 'one' }] });
+            espreeParseFn.onCall(1).returns({ comments: [{ value: 'two' }, { value: 'another two' }] });
+            espreeParseFn.onCall(2).returns({ comments: [{ value: 'three' }] });
+
+            doctrineParseFn = sinon.stub(doctrine, 'parse');
+            doctrineParseFn.callsFake((comment, options) => ({
+                description: comment + '-doctrine',
+                tags: [{ title: 'param', "description": "some param" }]
+            }));
+        });
+
+        describe('process', () => {
+            describe('provided with configuration options', () => {
+                beforeEach(() => {
+                    configuration = {
+                        cwd: 'cwd',
+                        pattern: 'pattern',
+                        ignore: ['ignore']
+                    };
+                    processor = new Processor(configuration);
+                    result = processor.process();
+                });
+
+                it('processes the code from the provided configuration options', () => {
+                    sinon.assert.calledWith(globSyncFn, 'pattern', { // provided pattern
+                        cwd: 'cwd', // provided cwd
+                        ignore: ['ignore'], // provided ignore
+                        nodir: true,
+                        nosort: true
+                    });
+                });
+
+                it('processes each file using espree', () => {
+                    sinon.assert.calledWith(espreeParseFn, path.join('cwd', 'one-content'));
+                    sinon.assert.calledWith(espreeParseFn, path.join('cwd', 'two-content'));
+                    sinon.assert.calledWith(espreeParseFn, path.join('cwd', 'three-content'));
+                });
+
+                it('processes each comment using doctrine', () => {
+                    sinon.assert.calledWith(doctrineParseFn, 'one');
+                    sinon.assert.calledWith(doctrineParseFn, 'two');
+                    sinon.assert.calledWith(doctrineParseFn, 'another two');
+                    sinon.assert.calledWith(doctrineParseFn, 'three');
+                });
+
+                it('returns the doctrine comments', () => {
+                    expect(result.length).toBe(4);
+                    expect(result[0]).toEqual({
+                        description: 'one-doctrine',
+                        tags: [{ title: 'param', "description": "some param" }]
+                    } as doctrine.Comment);
+                    expect(result[1]).toEqual({
+                        description: 'two-doctrine',
+                        tags: [{ title: 'param', "description": "some param" }]
+                    } as doctrine.Comment);
+                    expect(result[2]).toEqual({
+                        description: 'another two-doctrine',
+                        tags: [{ title: 'param', "description": "some param" }]
+                    } as doctrine.Comment);
+                    expect(result[3]).toEqual({
+                        description: 'three-doctrine',
+                        tags: [{ title: 'param', "description": "some param" }]
+                    } as doctrine.Comment);
+                });
+
+                afterEach(() => {
+                    globSyncFn.reset();
+                    fsReadFileSyncFn.reset();
+                    espreeParseFn.reset();
+                    doctrineParseFn.reset();
+                });
+            });
+
+            describe('provided without configuration options', () => {
+                beforeEach(() => {
+                    configuration = {};
+                    processor = new Processor(configuration);
+                    result = processor.process();
+                });
+
+                it('processes the code from the default configuration options', () => {
+                    sinon.assert.calledWith(globSyncFn, '**/*.js', { // default pattern
+                        cwd: process.cwd(), // default cwd
+                        ignore: [], // default ignore
+                        nodir: true,
+                        nosort: true
+                    });
+                });
+
+                it('processes each file using espree', () => {
+                    sinon.assert.calledWith(espreeParseFn, path.join(process.cwd(), 'one-content'));
+                    sinon.assert.calledWith(espreeParseFn, path.join(process.cwd(), 'two-content'));
+                    sinon.assert.calledWith(espreeParseFn, path.join(process.cwd(), 'three-content'));
+                });
+
+                it('processes each comment using doctrine', () => {
+                    sinon.assert.calledWith(doctrineParseFn, 'one');
+                    sinon.assert.calledWith(doctrineParseFn, 'two');
+                    sinon.assert.calledWith(doctrineParseFn, 'another two');
+                    sinon.assert.calledWith(doctrineParseFn, 'three');
+                });
+
+                it('returns the doctrine comments', () => {
+                    expect(result.length).toBe(4);
+                    expect(result[0]).toEqual({
+                        description: 'one-doctrine',
+                        tags: [{ title: 'param', "description": "some param" }]
+                    } as doctrine.Comment);
+                    expect(result[1]).toEqual({
+                        description: 'two-doctrine',
+                        tags: [{ title: 'param', "description": "some param" }]
+                    } as doctrine.Comment);
+                    expect(result[2]).toEqual({
+                        description: 'another two-doctrine',
+                        tags: [{ title: 'param', "description": "some param" }]
+                    } as doctrine.Comment);
+                    expect(result[3]).toEqual({
+                        description: 'three-doctrine',
+                        tags: [{ title: 'param', "description": "some param" }]
+                    } as doctrine.Comment);
+                });
+
+                afterEach(() => {
+                    globSyncFn.reset();
+                    fsReadFileSyncFn.reset();
+                    espreeParseFn.reset();
+                    doctrineParseFn.reset();
+                });
+            });
+        });
+
+        afterEach(() => {
+            globSyncFn.restore();
+            fsReadFileSyncFn.restore();
+            espreeParseFn.restore();
+            doctrineParseFn.restore();
+        });
+    });
+})();

--- a/lib/processor.spec.ts
+++ b/lib/processor.spec.ts
@@ -34,7 +34,7 @@ import * as path from 'path';
             doctrineParseFn = sinon.stub(doctrine, 'parse');
             doctrineParseFn.callsFake((comment, options) => ({
                 description: comment + '-doctrine',
-                tags: [{ title: 'param', "description": "some param" }]
+                tags: [{ title: 'param', 'description': 'some param' }]
             }));
         });
 
@@ -76,19 +76,19 @@ import * as path from 'path';
                     expect(result.length).toBe(4);
                     expect(result[0]).toEqual({
                         description: 'one-doctrine',
-                        tags: [{ title: 'param', "description": "some param" }]
+                        tags: [{ title: 'param', 'description': 'some param' }]
                     } as doctrine.Comment);
                     expect(result[1]).toEqual({
                         description: 'two-doctrine',
-                        tags: [{ title: 'param', "description": "some param" }]
+                        tags: [{ title: 'param', 'description': 'some param' }]
                     } as doctrine.Comment);
                     expect(result[2]).toEqual({
                         description: 'another two-doctrine',
-                        tags: [{ title: 'param', "description": "some param" }]
+                        tags: [{ title: 'param', 'description': 'some param' }]
                     } as doctrine.Comment);
                     expect(result[3]).toEqual({
                         description: 'three-doctrine',
-                        tags: [{ title: 'param', "description": "some param" }]
+                        tags: [{ title: 'param', 'description': 'some param' }]
                     } as doctrine.Comment);
                 });
 
@@ -133,19 +133,19 @@ import * as path from 'path';
                     expect(result.length).toBe(4);
                     expect(result[0]).toEqual({
                         description: 'one-doctrine',
-                        tags: [{ title: 'param', "description": "some param" }]
+                        tags: [{ title: 'param', 'description': 'some param' }]
                     } as doctrine.Comment);
                     expect(result[1]).toEqual({
                         description: 'two-doctrine',
-                        tags: [{ title: 'param', "description": "some param" }]
+                        tags: [{ title: 'param', 'description': 'some param' }]
                     } as doctrine.Comment);
                     expect(result[2]).toEqual({
                         description: 'another two-doctrine',
-                        tags: [{ title: 'param', "description": "some param" }]
+                        tags: [{ title: 'param', 'description': 'some param' }]
                     } as doctrine.Comment);
                     expect(result[3]).toEqual({
                         description: 'three-doctrine',
-                        tags: [{ title: 'param', "description": "some param" }]
+                        tags: [{ title: 'param', 'description': 'some param' }]
                     } as doctrine.Comment);
                 });
 

--- a/lib/processor.ts
+++ b/lib/processor.ts
@@ -1,0 +1,78 @@
+import Configuration from './configuration';
+import * as glob from 'glob';
+import * as espree from 'espree';
+import * as doctrine from 'doctrine';
+import * as path from 'path';
+import * as fs from 'fs-extra';
+
+/** Docs processor. */
+class Processor {
+    private DEFAULT_CWD = process.cwd();
+    private DEFAULT_PATTERN = '**/*.js';
+    private DEFAULT_IGNORE: string[] = [];
+    private ESPREE_PARSE_OPTIONS: espree.ParseOptions = {
+        comments: true,
+        attachComment: true,
+    };
+
+    private pattern: string;
+    private options: any;
+
+    /**
+     * Constructor.
+     * @param configuration The configuraton object.
+     */
+    constructor(private configuration: Configuration) {
+        this.pattern = configuration.pattern || this.DEFAULT_PATTERN;
+
+        this.options = {
+            cwd: configuration.cwd || this.DEFAULT_CWD,
+            ignore: configuration.ignore || this.DEFAULT_IGNORE,
+            nodir: true,
+            nosort: true
+        };
+    }
+
+    /**
+     * Process all matching files and return the comments.s
+     * @return {[Comment,Comment,Comment,Comment,Comment]}
+     */
+    process(): doctrine.Comment[] {
+        return glob
+            .sync(this.pattern, this.options)
+            .map(this._toEspreeComments)
+            .reduce(this._concatComments)
+            .map(this._toDoctrineComments);
+    }
+
+    /**
+     * Reads and parses the provided file using espree.
+     * @param file The file
+     * @return {Comment[]} comments The comments from the provided file.
+     * @private
+     */
+    private _toEspreeComments = (file: string): espree.Comment[] => {
+        const filename = path.join(this.options.cwd, file);
+        const code = fs.readFileSync(filename);
+        return espree.parse(code, this.ESPREE_PARSE_OPTIONS).comments;
+    };
+
+    /**
+     * Merge the comments.
+     * @param previousComments The list of previous comments.
+     * @param currentComments The list of current comments.
+     */
+    private _concatComments = (previousComments: espree.Comment[],
+                               currentComments: espree.Comment[]): espree.Comment[] =>
+        previousComments.concat(currentComments);
+
+    /**
+     * Converts the espree comments to doctrine comments.
+     * @param comment The comment.
+     * @private
+     */
+    private _toDoctrineComments = (comment: espree.Comment): doctrine.Comment =>
+        doctrine.parse(comment.value, { unwrap: true });
+}
+
+export default Processor;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "yadop",
+  "version": "1.0.0",
+  "description": "Yet another Doc Parser",
+  "main": "built/index.js",
+  "scripts": {
+    "lint": "tslint -p tsconfig.json",
+    "build": "tsc -p tsconfig.json",
+    "test": "jasmine-node built --match ."
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/devolksbank/yadop.git"
+  },
+  "keywords": [
+    "doctrine",
+    "espree",
+    "jsdoc",
+    "ngdoc"
+  ],
+  "author": "",
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "https://github.com/devolksbank/yadop/blob/master/LICENSE"
+    }
+  ],
+  "bugs": {
+    "url": "https://github.com/devolksbank/yadop/issues"
+  },
+  "homepage": "https://github.com/devolksbank/yadop#readme",
+  "devDependencies": {
+    "@types/fs-extra": "4.0.0",
+    "@types/glob": "5.0.32",
+    "@types/jasmine": "2.5.54",
+    "@types/node": "8.0.24",
+    "@types/sinon": "2.3.3",
+    "jasmine-node": "1.14.5",
+    "tslint": "5.6.0",
+    "tslint-eslint-rules": "4.1.1",
+    "typescript": "2.4.2",
+    "vrsource-tslint-rules": "5.1.1"
+  },
+  "dependencies": {
+    "doctrine": "2.0.0",
+    "espree": "3.5.0",
+    "fs-extra": "4.0.1",
+    "glob": "7.1.2",
+    "sinon": "3.2.1"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,7 +37,9 @@
     "types": [
       "fs-extra",
       "glob",
-      "node"
+      "jasmine",
+      "node",
+      "sinon"
     ]
   },
   "include": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,50 @@
+{
+  "compilerOptions": {
+    "allowUnreachableCode": false,
+    "allowUnusedLabels": false,
+    "baseUrl": ".",
+    "declaration": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "lib": [
+      "es6",
+      "es2015",
+      "dom"
+    ],
+    "module": "commonjs",
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitAny": true,
+    "noImplicitReturns": true,
+    "noImplicitUseStrict": false,
+    "noLib": false,
+    "outDir": "built",
+    "paths": {
+      "doctrine": [
+        "@types/doctrine/doctrine.d.ts"
+      ],
+      "espree": [
+        "@types/espree/espree.d.ts"
+      ]
+    },
+    "pretty": true,
+    "removeComments": true,
+    "sourceMap": true,
+    "target": "es5",
+    "typeRoots": [
+      "node_modules/@types",
+      "node_modules"
+    ],
+    "types": [
+      "fs-extra",
+      "glob",
+      "node"
+    ]
+  },
+  "include": [
+    "lib/**/*.ts",
+    "index.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     ],
     "module": "commonjs",
     "noFallthroughCasesInSwitch": true,
-    "noImplicitAny": true,
+    "noImplicitAny": false,
     "noImplicitReturns": true,
     "noImplicitUseStrict": false,
     "noLib": false,
@@ -27,7 +27,7 @@
       ]
     },
     "pretty": true,
-    "removeComments": true,
+    "removeComments": false,
     "sourceMap": true,
     "target": "es5",
     "typeRoots": [
@@ -44,7 +44,8 @@
   },
   "include": [
     "lib/**/*.ts",
-    "index.ts"
+    "index.ts",
+    "test/**/*.ts"
   ],
   "exclude": [
     "node_modules"

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,105 @@
+{
+  "rulesDirectory": [
+    "node_modules/vrsource-tslint-rules/rules",
+    "node_modules/tslint-eslint-rules/dist/rules"
+  ],
+  "rules": {
+    "callable-types": true,
+    "class-name": true,
+    "comment-format": [
+      true,
+      "check-space"
+    ],
+    "curly": true,
+    "eofline": true,
+    "forin": true,
+    "import-blacklist": [true, "rxjs"],
+    "import-spacing": true,
+    "indent": [
+      true,
+      "spaces"
+    ],
+    "interface-over-type-literal": true,
+    "label-position": true,
+    "max-line-length": [
+      true,
+      140
+    ],
+    "member-access": false,
+    "member-ordering": [
+      true,
+      "static-before-instance",
+      "variables-before-functions"
+    ],
+    "no-arg": true,
+    "no-bitwise": true,
+    "no-console": [
+      true,
+      "debug",
+      "info",
+      "time",
+      "timeEnd",
+      "trace"
+    ],
+    "no-construct": true,
+    "no-debugger": true,
+    "no-duplicate-imports": true,
+    "no-duplicate-variable": true,
+    "no-empty": false,
+    "no-empty-interface": true,
+    "no-eval": true,
+    "no-inferrable-types": true,
+    "no-inner-declarations": [true, "function"],
+    "no-jasmine-focus": true,
+    "no-shadowed-variable": true,
+    "no-string-literal": false,
+    "no-string-throw": true,
+    "no-switch-case-fall-through": true,
+    "no-trailing-whitespace": true,
+    "no-unused-expression": true,
+    "no-use-before-declare": false,
+    "no-var-keyword": true,
+    "object-literal-sort-keys": false,
+    "one-line": [
+      true,
+      "check-open-brace",
+      "check-catch",
+      "check-else",
+      "check-whitespace"
+    ],
+    "prefer-const": true,
+    "quotemark": [
+      true,
+      "single"
+    ],
+    "radix": true,
+    "semicolon": [
+      "always"
+    ],
+    "triple-equals": [
+      true,
+      "allow-null-check"
+    ],
+    "typedef-whitespace": [
+      true,
+      {
+        "call-signature": "nospace",
+        "index-signature": "nospace",
+        "parameter": "nospace",
+        "property-declaration": "nospace",
+        "variable-declaration": "nospace"
+      }
+    ],
+    "typeof-compare": true,
+    "unified-signatures": true,
+    "variable-name": [true, "ban-keywords"],
+    "whitespace": [
+      true,
+      "check-branch",
+      "check-decl",
+      "check-operator",
+      "check-separator",
+      "check-type"
+    ]
+  }
+}


### PR DESCRIPTION
- Adds the yadop.jsdoc.processor functionality to process an entire directory and get all the jsdoc comments.
- Adds the yadop.ngdoc.processor functionality to process an entire directory and get all the ngdoc comments.
- Adds the yadop.ngdoc.mapper functionality to map all the ngdoc comments to a usable module tree.