### PR TITLE
feat(tags): allow for aliases of tags as per the jsdoc documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,8 @@ typings/
 # dotenv environment variables file
 .env
 
+# IDE files
+*.iml
+
+#output of ts
+built/

--- a/lib/ngdoc/ngdocMapper.spec.ts
+++ b/lib/ngdoc/ngdocMapper.spec.ts
@@ -89,7 +89,11 @@ import {Method} from './model/method';
                     title: 'param', description: 'Who said it', name: 'who',
                     type: { type: 'NameExpression', name: 'string' }
                 },
-                { title: 'param', description: 'When to say', name: 'when', 'type': null } // no type
+                { title: 'param', description: 'When to say', name: 'when', 'type': null }, // no type
+                {
+                    title: 'returns', description: 'message The message',
+                    type: { type: 'NameExpression', name: 'object' }
+                }
             ]
         } as doctrine.Annotation, { // another entity method
             tags: [
@@ -146,7 +150,8 @@ import {Method} from './model/method';
                             params: [{ name: 'who', description: 'Who said it', type: 'string' }, {
                                 name: 'when',
                                 description: 'When to say'
-                            }]
+                            }],
+                            returns: { name: 'message The message', type: 'object' }
                         }, {
                             name: 'welcome',
                             description: 'Say welcome',
@@ -236,7 +241,8 @@ import {Method} from './model/method';
                     params: [
                         { name: 'who', description: 'Who said it', type: 'string' }, // with a type
                         { name: 'when', description: 'When to say' } // without type (not specified)
-                    ] // no return type
+                    ],
+                    returns: { name: 'message The message', type: 'object' }
                 });
                 expect(serviceMethod[1]).toEqual({
                     name: 'welcome',

--- a/lib/ngdoc/tags.ts
+++ b/lib/ngdoc/tags.ts
@@ -1,4 +1,5 @@
 import * as doctrine from 'doctrine';
+
 export namespace tags {
     export namespace annotations {
 
@@ -8,7 +9,7 @@ export namespace tags {
          * @return {boolean} indicator The indicator.
          */
         export function description(tag: doctrine.Tag): boolean {
-            return _onlyAtTags(tag, 'description');
+            return _onlyAtTags(tag, ['description', 'desc']);
         }
 
         /**
@@ -17,7 +18,7 @@ export namespace tags {
          * @return {boolean} indicator The indicator.
          */
         export function deprecated(tag: doctrine.Tag): boolean {
-            return _onlyAtTags(tag, 'deprecated');
+            return _onlyAtTags(tag, ['deprecated']);
         }
 
         /**
@@ -26,7 +27,7 @@ export namespace tags {
          * @return {boolean} indicator The indicator.
          */
         export function methodOfTag(tag: doctrine.Tag): boolean {
-            return _onlyAtTags(tag, 'methodOf');
+            return _onlyAtTags(tag, ['methodOf']);
         }
 
         /**
@@ -35,7 +36,7 @@ export namespace tags {
          * @return {boolean} indicator The indicator.
          */
         export function module(tag: doctrine.Tag): boolean {
-            return _onlyAtTags(tag, 'module');
+            return _onlyAtTags(tag, ['module']);
         }
 
         /**
@@ -44,7 +45,7 @@ export namespace tags {
          * @return {boolean} indicator The indicator.
          */
         export function name(tag: doctrine.Tag): boolean {
-            return _onlyAtTags(tag, 'name');
+            return _onlyAtTags(tag, ['name']);
         }
 
         /**
@@ -53,7 +54,7 @@ export namespace tags {
          * @return {boolean} indicator The indicator.
          */
         export function ngdoc(tag: doctrine.Tag): boolean {
-            return _onlyAtTags(tag, 'ngdoc');
+            return _onlyAtTags(tag, ['ngdoc']);
         }
 
         /**
@@ -62,7 +63,7 @@ export namespace tags {
          * @return {boolean} indicator The indicator.
          */
         export function param(tag: doctrine.Tag): boolean {
-            return _onlyAtTags(tag, 'param');
+            return _onlyAtTags(tag, ['param', 'arg', 'argument']);
         }
 
         /**
@@ -71,7 +72,7 @@ export namespace tags {
          * @return {boolean} indicator The indicator.
          */
         export function requires(tag: doctrine.Tag): boolean {
-            return _onlyAtTags(tag, 'requires');
+            return _onlyAtTags(tag, ['requires']);
         }
 
         /**
@@ -80,17 +81,18 @@ export namespace tags {
          * @return {boolean} indicator The indicator.
          */
         export function returns(tag: doctrine.Tag): boolean {
-            return _onlyAtTags(tag, 'return');
+            return _onlyAtTags(tag, ['returns', 'return']);
         }
 
         /**
          * Indicates if the tag is contains a @name tag.
          * @param tag The tag.
+         * @param tagNames List of tag name aliases
          * @return {boolean} indicator The indicator.
          * @private
          */
-        export function _onlyAtTags(tag: doctrine.Tag, tagName): boolean {
-            return tag.title === tagName;
+        export function _onlyAtTags(tag: doctrine.Tag, tagNames: string[]): boolean {
+            return tagNames.some(tagName => tag.title === tagName);
         }
     }
 
@@ -101,7 +103,7 @@ export namespace tags {
          * @return {boolean} indicator The indicator.
          */
         export function method(tag: doctrine.Tag): boolean {
-            return tag.description === 'method'
+            return ['function', 'func', 'method'].some(tagName => tag.description === tagName)
         }
 
         /**


### PR DESCRIPTION
As per the documentation of jsdoc: http://usejsdoc.org/ some tags have aliases which should be supported as well.